### PR TITLE
 Use environment files instead of set-output command

### DIFF
--- a/.github/workflows/rebuild-and-push-image.yml
+++ b/.github/workflows/rebuild-and-push-image.yml
@@ -3,20 +3,20 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - $default-branch
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Extract version and set tag
         shell: bash
         run: |
-          echo "::set-output name=version::$(cat VERSION)"
-          echo "::set-output name=tags::$(cat VERSION) latest"
+          echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+          echo "tags=$(cat VERSION) latest" >> $GITHUB_OUTPUT
         id: version_tags
 
       - name: Build Image


### PR DESCRIPTION
Related to packit/deployment#396

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
